### PR TITLE
Fix issues when calculating float weights

### DIFF
--- a/apg-shipping.php
+++ b/apg-shipping.php
@@ -562,6 +562,11 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php' ) || is_network_only_plugin
 					$clases[ 'sin-clase' ]	+= $clases[ 'todas' ];
 				}
 
+				//Correct float values operations issues
+				if ( $clases[ 'todas' ] < 0.00001 ) {
+		                    $clases[ 'todas' ] = 0;
+                		}
+
 				//Aplicamos tarifas
 				foreach ( $tarifas as $tipo => $tarifas_por_tipo ) {	
 					//Variable


### PR DESCRIPTION
Hi,

I am having issues with some carts on the weight calculations. The weights are all floating values and with certain carts, the piece of code that readjusts the weight per shipping class fails because of rounding issues, which means `$clases[ 'todas' ]` is not equal to 0, but a very close number to 0. This cause the shipping price to be the highest number instead of the expected shipping class.

This piece of code solves the issue, please tell me what you think.

Note : for some reason, `PHP_FLOAT_EPSILON` is too small, the fix isn't working with it.